### PR TITLE
chore: release 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+## [0.4.2](https://github.com/supabase-community/storage-ex/compare/v0.4.2...v0.4.2) (2025-07-15)
+
+
+### config
+
+* release-please ([#7](https://github.com/supabase-community/storage-ex/issues/7)) ([0b4382e](https://github.com/supabase-community/storage-ex/commit/0b4382e1ddd2aa96483e4fd34fbba5db976839c8))
+
+
+### Features
+
+* follow base SDK update ([6cf4c56](https://github.com/supabase-community/storage-ex/commit/6cf4c56f08c8a81c674f91b47a2dfb90b7796959))
+* port from supabase-potion ([8373482](https://github.com/supabase-community/storage-ex/commit/83734820566fa463fcee7167dab3685d6801a8ec))
+* release 0.3.0 ([6ddea65](https://github.com/supabase-community/storage-ex/commit/6ddea6586c26b38a2517a2d3fce0fb32766ffd33))
+
+
+### Bug Fixes
+
+* remove empty transform struct when generating document URLs ([#6](https://github.com/supabase-community/storage-ex/issues/6)) ([bb19e5d](https://github.com/supabase-community/storage-ex/commit/bb19e5d2d7e001107de6a0213ec3926905731ce3))
+
+
+### Code Refactoring
+
+* follow storage-js ([#4](https://github.com/supabase-community/storage-ex/issues/4)) ([f5c7803](https://github.com/supabase-community/storage-ex/commit/f5c7803ea5b2aee863bb78b398aad731aa258cf0))
+* match with new supabase_potion release ([#3](https://github.com/supabase-community/storage-ex/issues/3)) ([90ad694](https://github.com/supabase-community/storage-ex/commit/90ad694f596065ba3373761a85927f9534476dc8))


### PR DESCRIPTION
:rocket: Want to release this?
---


## [0.4.2](https://github.com/supabase-community/storage-ex/compare/v0.4.2...v0.4.2) (2025-07-15)


### config

* release-please ([#7](https://github.com/supabase-community/storage-ex/issues/7)) ([0b4382e](https://github.com/supabase-community/storage-ex/commit/0b4382e1ddd2aa96483e4fd34fbba5db976839c8))


### Features

* follow base SDK update ([6cf4c56](https://github.com/supabase-community/storage-ex/commit/6cf4c56f08c8a81c674f91b47a2dfb90b7796959))
* port from supabase-potion ([8373482](https://github.com/supabase-community/storage-ex/commit/83734820566fa463fcee7167dab3685d6801a8ec))
* release 0.3.0 ([6ddea65](https://github.com/supabase-community/storage-ex/commit/6ddea6586c26b38a2517a2d3fce0fb32766ffd33))


### Bug Fixes

* remove empty transform struct when generating document URLs ([#6](https://github.com/supabase-community/storage-ex/issues/6)) ([bb19e5d](https://github.com/supabase-community/storage-ex/commit/bb19e5d2d7e001107de6a0213ec3926905731ce3))


### Code Refactoring

* follow storage-js ([#4](https://github.com/supabase-community/storage-ex/issues/4)) ([f5c7803](https://github.com/supabase-community/storage-ex/commit/f5c7803ea5b2aee863bb78b398aad731aa258cf0))
* match with new supabase_potion release ([#3](https://github.com/supabase-community/storage-ex/issues/3)) ([90ad694](https://github.com/supabase-community/storage-ex/commit/90ad694f596065ba3373761a85927f9534476dc8))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).